### PR TITLE
fix: fix --disable_webrtc to update the module variable correctly

### DIFF
--- a/spyglass/__init__.py
+++ b/spyglass/__init__.py
@@ -9,3 +9,7 @@ if importlib.util.find_spec("aiortc"):
     WEBRTC_ENABLED=True
 else:
     WEBRTC_ENABLED=False
+
+def set_webrtc_enabled(enabled):
+    global WEBRTC_ENABLED
+    WEBRTC_ENABLED = enabled

--- a/spyglass/cli.py
+++ b/spyglass/cli.py
@@ -8,7 +8,7 @@ import re
 import sys
 import libcamera
 
-from spyglass import camera_options, logger, WEBRTC_ENABLED
+from spyglass import camera_options, logger, WEBRTC_ENABLED, set_webrtc_enabled
 from spyglass.exif import option_to_exif_orientation
 from spyglass.__version__ import __version__
 
@@ -45,7 +45,7 @@ def main(args=None):
     if parsed_args.controls_string:
         controls += [c.split('=') for c in parsed_args.controls_string.split(',')]
 
-    WEBRTC_ENABLED = WEBRTC_ENABLED and not parsed_args.disable_webrtc
+    set_webrtc_enabled(WEBRTC_ENABLED and not parsed_args.disable_webrtc)
 
     # Has to be imported after WEBRTC_ENABLED got set correctly
     from spyglass.camera import init_camera


### PR DESCRIPTION
`WEBRTC_ENABLED` did not get updated correctly in `spyglas/__init__.py` resulting in WebRTC not getting disabled with `--disable_webrtc`.