### PR TITLE
ci: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ permissions:
 
 jobs:
   push_to_main:
+    name: FF Merge and Bump version
     runs-on: ubuntu-latest
-    name: "FF Merge and Bump version"
     outputs:
       version: ${{ steps.bump.outputs.version }}
 
@@ -19,6 +19,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: 'main'
+
     - name: Fast Forward Merge To Main
       uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
       with:
@@ -33,6 +34,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         changelog_increment_filename: release_body.md
+
     - name: Fast Forward Merge To Develop
       uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
       with:
@@ -48,33 +50,38 @@ jobs:
         path: release_body.md
 
   release:
+    name: Create Release
     needs: push_to_main
     runs-on: ubuntu-latest
-    name: "Create Release"
     steps:
     - name: Download Release Body
       uses: actions/download-artifact@v4
       with:
         name: release-body.md
         path: .
+
     - name: Check out
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: 'main'
+
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.10'
         cache: 'pip'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
     - name: Build package
       run: |
         python -m build
+
     - name: Release
       uses: softprops/action-gh-release@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump.outputs.version }}
-
     steps:
     - name: Check out
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,11 @@ jobs:
       with:
         name: release-body.md
         path: .
+    - name: Check out
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: 'main'
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   push_to_master:
     runs-on: ubuntu-latest
-    name: "fast-forward develop to main"
+    name: "FF Merge and Bump version"
     outputs:
       version: ${{ steps.bump.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,53 +1,80 @@
 name: Release version
 
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  release-version:
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+  push_to_master:
     runs-on: ubuntu-latest
-    name: "Bump version, create changelog and release"
+    name: "fast-forward develop to main"
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
 
     steps:
-      - name: Check out
-        uses: actions/checkout@v3
-        with:
-          token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"
-          fetch-depth: 0
+    - name: Check out
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: 'main'
+    - name: Fast Forward Merge To Master
+      uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
+      with:
+        branchtomerge: origin/develop
+        branch: master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-          cache: 'pip'
+    - name: Create bump and changelog
+      uses: commitizen-tools/commitizen-action@master
+      id: bump
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        changelog_increment_filename: release_body.md
+    - name: Fast Forward Merge To Develop
+      uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
+      with:
+        branchtomerge: master
+        branch: develop
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Upload Release Body
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-body.md
+        path: release_body.md
 
-      - name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
-        id: bump
-        with:
-          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          changelog_increment_filename: release_body.md
-
-      - name: Build package
-        run: |
-          python -m build
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: release_body.md
-          tag_name: ${{ env.REVISION }}
-          files: dist/*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    needs: push_to_master
+    runs-on: ubuntu-latest
+    name: "Create Release"
+    steps:
+    - name: Download Release Body
+      uses: actions/download-artifact@v4
+      with:
+        name: release-body.md
+        path: .
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Build package
+      run: |
+        python -m build
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        body_path: release_body.md
+        tag_name: ${{ needs.push_to_master.outputs.version }}
+        files: dist/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 
 jobs:
-  push_to_master:
+  push_to_main:
     runs-on: ubuntu-latest
     name: "FF Merge and Bump version"
     outputs:
@@ -19,11 +19,11 @@ jobs:
       with:
         fetch-depth: 0
         ref: 'main'
-    - name: Fast Forward Merge To Master
+    - name: Fast Forward Merge To Main
       uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
       with:
         branchtomerge: origin/develop
-        branch: master
+        branch: main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -36,7 +36,7 @@ jobs:
     - name: Fast Forward Merge To Develop
       uses: MaximeHeckel/github-action-merge-fast-forward@v1.1.0
       with:
-        branchtomerge: master
+        branchtomerge: main
         branch: develop
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
         path: release_body.md
 
   release:
-    needs: push_to_master
+    needs: push_to_main
     runs-on: ubuntu-latest
     name: "Create Release"
     steps:
@@ -74,7 +74,7 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         body_path: release_body.md
-        tag_name: ${{ needs.push_to_master.outputs.version }}
+        tag_name: ${{ needs.push_to_main.outputs.version }}
         files: dist/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This changes the release workflow to manual trigger and to use fast-forward merge instead of merge commits. This will use a develop branch to merge future PRs and then release through a manual trigger.