### PR TITLE
ci: fix dependabot.yml to target develop branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    targget-branch: "develop"
+    target-branch: "develop"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    targget-branch: "develop"


### PR DESCRIPTION
I changed the developing workflow to use a develop branch and do fast-forward merges. Therefore dependabot also needs to push to develop that main and develop keep a linear history.