### PR TITLE
ci: fix pytest failing for unknown reason

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
 
       - name: Install dependencies


### PR DESCRIPTION
Pytest is failing on Python 3.10. The failed tests should not fail, as Spyglass is working as intended.
It seems to be some bug in pytest for some python versions.

The test is failing as it cannot find the `camera` submodule of `spyglass`, but it's obviously there:
https://github.com/mryel00/spyglass/actions/runs/18204099599/job/51830092834

Therefore I increase the Python version just for this job.