### PR TITLE
chore: remove unused stuff and update min python version to match aiortc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,11 +12,9 @@ authors = [
 ]
 license = "GPL-3.0-only"
 license-files = ["LICENSE", "NOTICE"]
-requires-python = ">=3.8.1"
+requires-python = ">=3.9"
 dependencies = [
     "aiortc~=1.13.0",
-    "av~=10.0.0; platform_machine=='armv7l' and python_version=='3.9'",
-    "cffi~=1.17.1; platform_machine=='armv7l' and python_version=='3.9'"
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 aiortc~=1.13.0
-setuptools~=80.9.0


### PR DESCRIPTION
32 bit support dropped as mentioned here: https://github.com/mryel00/spyglass/issues/116#issuecomment-3361184578

setuptools is not needed anymore

Python 3.8 support got dropped by aiortc, therefore updating our needed version too